### PR TITLE
Longview test fixes

### DIFF
--- a/packages/manager/e2e/config/wdio.conf.js
+++ b/packages/manager/e2e/config/wdio.conf.js
@@ -85,6 +85,7 @@ exports.config = {
   // debug: true,
   // execArgv: ['--inspect=127.0.0.1:5859'],
   // Selenium Host/Port
+  runner: 'local',
   hostname: process.env.DOCKER ? 'selenium' : 'localhost',
   port: 4444,
   //

--- a/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
@@ -1,4 +1,5 @@
 const { assertLog } = require('../../utils/assertionLog');
+const { constants } = require('../../constants');
 import Page from '../page';
 
 class LongviewLanding extends Page {
@@ -116,7 +117,7 @@ class LongviewLanding extends Page {
     this.deleteButton.click();
     this.dialogAlert.waitForDisplayed();
     this.lvDelete.click();
-    this.dialogAlert.waitForDisplayed(true);
+    this.dialogAlert.waitForExist(constants.wait.normal, true);
   }
 
   deleteLVClientsAPI(token, lvClients) {

--- a/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
@@ -104,13 +104,13 @@ class LongviewPlanDetails extends Page {
     expect(this.isCurrentPlan(clientCount))
       .withContext(`should be current plan`)
       .toBe(true);
-    // expect(planRow.$('[data-qa-radio="true"]'))
-    //   .withContext(`Plan radio button ${assertLog.enabled}`)
-    //   .toBe(true);
+    expect(planRow.$('[data-qa-radio="true"]').isEnabled())
+      .withContext(`Plan radio button ${assertLog.enabled}`)
+      .toBe(true);
 
-    // expect(this.changePlanButton.isEnabled())
-    //   .withContext(`Change plan button ${assertLog.notEnabled}`)
-    //   .toBe(false);
+    expect(this.changePlanButton.isEnabled())
+      .withContext(`Change plan button ${assertLog.notEnabled}`)
+      .toBe(false);
   }
   // Used for selecting or using any longview plan row
   selectLongviewPlan(clientCount) {

--- a/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
@@ -49,8 +49,8 @@ class LongviewPlanDetails extends Page {
 
   isCurrentPlan(clientCount) {
     return $(
-      `[data-testid=lv-sub-table-row-longview-${clientCount}] [data-testid=current-plan]`
-    ).isDisplayed();
+      `[data-testid="lv-sub-table-row-longview-${clientCount}"] [data-testid="current-plan"]`
+    ).isExisting();
   }
 
   resetToFree() {
@@ -104,13 +104,13 @@ class LongviewPlanDetails extends Page {
     expect(this.isCurrentPlan(clientCount))
       .withContext(`should be current plan`)
       .toBe(true);
-    expect(planRow.$('data-qa-radio=true]'))
-      .withContext(`Plan radio button ${assertLog.enabled}`)
-      .toBe(true);
+    // expect(planRow.$('[data-qa-radio="true"]'))
+    //   .withContext(`Plan radio button ${assertLog.enabled}`)
+    //   .toBe(true);
 
-    expect(this.changePlanButton.isEnabled())
-      .withContext(`Change plan button ${assertLog.notEnabled}`)
-      .toBe(false);
+    // expect(this.changePlanButton.isEnabled())
+    //   .withContext(`Change plan button ${assertLog.notEnabled}`)
+    //   .toBe(false);
   }
   // Used for selecting or using any longview plan row
   selectLongviewPlan(clientCount) {

--- a/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
+++ b/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
@@ -91,12 +91,13 @@ describe('longview suite', () => {
         LongviewPlan.planDetailsDisplay();
       }
     });
+
     it('checks that longview plan can be changed', () => {
-      // checks for managed account
+      // // checks for managed account
       expect(LongviewLanding.checkForManaged(token))
         .withContext(`${managedAccount}`)
         .toBe(false);
-      // Changes a plan
+      // // Changes a plan
       expect(LongviewPlan.isCurrentPlan('free'))
         .withContext(`free plan should be set`)
         .toBe(true);
@@ -117,7 +118,7 @@ describe('longview suite', () => {
       const lvError = `Too many active Longview clients (${clientCount.length}) for the subscription selected (3). Select a larger subscription or reduce the number of Longview clients.`;
       LongviewPlan.lv3Plan.click();
       LongviewPlan.changePlanButton.click();
-      $('[data-qa-notice').waitForDisplayed();
+      $('[data-qa-notice]').waitForDisplayed();
       expect($('[data-qa-error="true"]').isDisplayed())
         .withContext(`Client count error ${assertLog.displayed}`)
         .toBe(true);


### PR DESCRIPTION
This should resolve the issues with the `?` for the test results. There were several issues, but i think the `?` in the jasmine test logger was caused by line 107 of `packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js`:

the original assertion was written as:

```
expect(planRow.$('data-qa-radio=true]'))
  .withContext('Plan radio button enabled')
  .toBe(true)
```

this was problematic for a few reasons

1. planRow.$('data-qa-radio=true]') is not a valid selector, so it would throw an error. I fixed the selector
2. the jasmine logger probably threw a weird `?` on the assertion `expect(planRow.$('[data-qa-radio="true"]')).toBe(true)` because that value is not a boolean, it's a web element object returned by selenium
3. i added a method that will return a boolean `isEnabled` and the assertion and the logger reported the test as expected.


I also fixed a few other issues. 

Notably, `waitForDisplayed(true)` is not valid correct usage of the method, `waitForDisplayed(timeout, reverse)`. Also the `Displayed` methods imply that a thing exists in the DOM but is not visible to the user (in the viewport), but i've found that if it doesn't exist in the DOM that method may throw an error. I've replaced that with `waitForExist` in one or two places.